### PR TITLE
bid name by length

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,6 @@ CORES=`getconf _NPROCESSORS_ONLN`
 mkdir -p build
 rm -f build/CMakeCache.txt
 pushd build &> /dev/null
-cmake ../
+cmake -DCMAKE_BUILD_TYPE=Debug ../
 make -j${CORES}
 popd &> /dev/null

--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,6 @@ CORES=`getconf _NPROCESSORS_ONLN`
 mkdir -p build
 rm -f build/CMakeCache.txt
 pushd build &> /dev/null
-cmake -DCMAKE_BUILD_TYPE=Debug ../
+cmake ../
 make -j${CORES}
 popd &> /dev/null

--- a/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/eosio.system/include/eosio.system/eosio.system.hpp
@@ -215,7 +215,7 @@ namespace eosiosystem {
          static constexpr eosio::name gov_account{"bos.gov"_n};
          static constexpr symbol ramcore_symbol = symbol(symbol_code("RAMCORE"), 4);
          static constexpr symbol ram_symbol     = symbol(symbol_code("RAM"), 0);
-
+         static const int16_t BASE_LENGTH = 4;
          system_contract( name s, name code, datastream<const char*> ds );
          ~system_contract();
 

--- a/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/eosio.system/include/eosio.system/eosio.system.hpp
@@ -43,22 +43,11 @@ namespace eosiosystem {
       uint64_t primary_key()const { return bidder.value; }
    };
 
-    struct [[eosio::table, eosio::contract("eosio.system")]] bid_close {
-      uint64_t             length = 0; /// the name length
-      block_timestamp      last_name_close;
-      uint64_t primary_key()const { return length; }
-
-      // explicit serialization macro is not necessary, used here only to improve compilation time
-      EOSLIB_SERIALIZE( bid_close, (length)(last_name_close))
-   };
-
-
    typedef eosio::multi_index< "namebids"_n, name_bid,
                                indexed_by<"highbid"_n, const_mem_fun<name_bid, uint64_t, &name_bid::by_high_bid>  >
                              > name_bid_table;
 
    typedef eosio::multi_index< "bidrefunds"_n, bid_refund > bid_refund_table;
-   typedef eosio::multi_index< "bidcloses"_n, bid_close > bid_close_table;
 
    struct [[eosio::table("global"), eosio::contract("eosio.system")]] eosio_global_state : eosio::blockchain_parameters {
       uint64_t free_ram()const { return max_ram_size - total_ram_bytes_reserved; }

--- a/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/eosio.system/include/eosio.system/eosio.system.hpp
@@ -43,11 +43,22 @@ namespace eosiosystem {
       uint64_t primary_key()const { return bidder.value; }
    };
 
+    struct [[eosio::table, eosio::contract("eosio.system")]] bid_close {
+      uint64_t             length = 0; /// the name length
+      block_timestamp      last_name_close;
+      uint64_t primary_key()const { return length; }
+
+      // explicit serialization macro is not necessary, used here only to improve compilation time
+      EOSLIB_SERIALIZE( bid_close, (length)(last_name_close))
+   };
+
+
    typedef eosio::multi_index< "namebids"_n, name_bid,
                                indexed_by<"highbid"_n, const_mem_fun<name_bid, uint64_t, &name_bid::by_high_bid>  >
                              > name_bid_table;
 
    typedef eosio::multi_index< "bidrefunds"_n, bid_refund > bid_refund_table;
+   typedef eosio::multi_index< "bidcloses"_n, bid_close > bid_close_table;
 
    struct [[eosio::table("global"), eosio::contract("eosio.system")]] eosio_global_state : eosio::blockchain_parameters {
       uint64_t free_ram()const { return max_ram_size - total_ram_bytes_reserved; }

--- a/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/eosio.system/include/eosio.system/eosio.system.hpp
@@ -384,6 +384,7 @@ namespace eosiosystem {
                                                double shares_rate, bool reset_to_zero = false );
          double update_total_votepay_share( time_point ct,
                                             double additional_shares_delta = 0.0, double shares_rate_delta = 0.0 );
+
    };
 
 } /// eosiosystem

--- a/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/eosio.system/include/eosio.system/eosio.system.hpp
@@ -373,7 +373,6 @@ namespace eosiosystem {
                                                double shares_rate, bool reset_to_zero = false );
          double update_total_votepay_share( time_point ct,
                                             double additional_shares_delta = 0.0, double shares_rate_delta = 0.0 );
-
    };
 
 } /// eosiosystem

--- a/eosio.system/src/eosio.system.cpp
+++ b/eosio.system/src/eosio.system.cpp
@@ -233,7 +233,6 @@ namespace eosiosystem {
       );
 
       name_bid_table bids(_self, _self.value);
-      static const uint64_t BASE_LENGTH = 4;
 
       if (newname.length() < BASE_LENGTH)
       {

--- a/eosio.system/src/eosio.system.cpp
+++ b/eosio.system/src/eosio.system.cpp
@@ -233,17 +233,18 @@ namespace eosiosystem {
       );
 
       name_bid_table bids(_self, _self.value);
-
-      static const int16_t BASE_LENGTH = 4;
+      static const uint64_t BASE_LENGTH = 4;
 
       if (newname.length() < BASE_LENGTH)
       {
+         
          auto idx = bids.get_index<"highbid"_n>();
          auto highest = idx.lower_bound(std::numeric_limits<uint64_t>::max() / 2);
+        
          if (highest != idx.end() &&
              highest->high_bid > 0)
          {
-            eosio_assert(bid.amount - highest->high_bid > (highest->high_bid / 10), "newname which length is less than 3  must increase bid by 10% than highest bid in all bid ");
+           eosio_assert(bid.amount - highest->high_bid > (highest->high_bid / 10), "newname which length is less than 3  must increase bid by 10% than highest bid in all bid ");
          }
       }
 

--- a/eosio.system/src/eosio.system.cpp
+++ b/eosio.system/src/eosio.system.cpp
@@ -234,12 +234,18 @@ namespace eosiosystem {
 
       name_bid_table bids(_self, _self.value);
 
-       auto idx = bids.get_index<"highbid"_n>();
-            auto highest = idx.lower_bound(std::numeric_limits<uint64_t>::max() / 2);
-            if (highest != idx.end() &&
-                highest->high_bid > 0){
-eosio_assert( bid.amount - highest->high_bid > (highest->high_bid / 10), "newname which length is less than 3  must increase bid by 10% than highest bid in all bid " );
-                }       
+      static const int16_t BASE_LENGTH = 4;
+
+      if (newname.length() < BASE_LENGTH)
+      {
+         auto idx = bids.get_index<"highbid"_n>();
+         auto highest = idx.lower_bound(std::numeric_limits<uint64_t>::max() / 2);
+         if (highest != idx.end() &&
+             highest->high_bid > 0)
+         {
+            eosio_assert(bid.amount - highest->high_bid > (highest->high_bid / 10), "newname which length is less than 3  must increase bid by 10% than highest bid in all bid ");
+         }
+      }
 
       print( name{bidder}, " bid ", bid, " on ", name{newname}, "\n" );
       auto current = bids.find( newname.value );

--- a/eosio.system/src/eosio.system.cpp
+++ b/eosio.system/src/eosio.system.cpp
@@ -243,7 +243,8 @@ namespace eosiosystem {
          if (highest != idx.end() &&
              highest->high_bid > 0)
          {
-           eosio_assert(bid.amount - highest->high_bid > (highest->high_bid / 10), "newname which length is less than 3  must increase bid by 10% than highest bid in all bid ");
+           std::string msg= "newname which length is less than 3  must increase bid by 10% than the highest bid in all bid :current value:"+std::to_string(highest->high_bid );
+           eosio_assert(bid.amount - highest->high_bid > (highest->high_bid / 10),msg.c_str());
          }
       }
 

--- a/eosio.system/src/eosio.system.cpp
+++ b/eosio.system/src/eosio.system.cpp
@@ -233,6 +233,14 @@ namespace eosiosystem {
       );
 
       name_bid_table bids(_self, _self.value);
+
+       auto idx = bids.get_index<"highbid"_n>();
+            auto highest = idx.lower_bound(std::numeric_limits<uint64_t>::max() / 2);
+            if (highest != idx.end() &&
+                highest->high_bid > 0){
+eosio_assert( bid.amount - highest->high_bid > (highest->high_bid / 10), "newname which length is less than 3  must increase bid by 10% than highest bid in all bid " );
+                }       
+
       print( name{bidder}, " bid ", bid, " on ", name{newname}, "\n" );
       auto current = bids.find( newname.value );
       if( current == bids.end() ) {

--- a/eosio.system/src/producer_pay.cpp
+++ b/eosio.system/src/producer_pay.cpp
@@ -58,9 +58,13 @@ namespace eosiosystem {
          for (auto &n : ns)
          {
             auto highest = bids.find(n.value);
+            if(highest != bids.end())
+            {
+            //  print( highest->last_bid_time.sec_since_epoch(), " dealed high_bid: ", highest->high_bid, " newname: ", name{highest->newname}, "\n" );
             bids.modify(highest, same_payer, [&](auto &b) {
                b.high_bid = -b.high_bid;
             });
+            }
          }
       };
 
@@ -71,7 +75,6 @@ namespace eosiosystem {
          }
          std::vector<name> names;
          static const int16_t COUNT10 = 10;
-
          uint16_t deal_count = 0;
 
          if (highest->newname.length() >= BASE_LENGTH)
@@ -80,16 +83,17 @@ namespace eosiosystem {
          }
 
          names.push_back(highest->newname);
-
+      //   print( highest->last_bid_time.sec_since_epoch(), " deal high_bid: ", highest->high_bid, " newname: ", name{highest->newname}, "\n" );
          for (int16_t i = 0; ++highest != idx.end() && i < COUNT10; i++)
          {
-           
+         //   print( highest->last_bid_time.sec_since_epoch(), " high_bid: ", highest->high_bid, " newname: ", name{highest->newname}, "\n" );
             if (highest->high_bid > 0 &&
                 (current_time_point() - highest->last_bid_time) > microseconds(useconds_per_day) &&
                 highest->newname.length() >= BASE_LENGTH)
             {
                names.push_back(highest->newname);
                deal_count++;
+               // print( highest->last_bid_time.sec_since_epoch(), " deal high_bid: ", highest->high_bid, " newname: ", name{highest->newname}, "\n" );
             }
 
             if (COUNT10 == deal_count)
@@ -112,7 +116,7 @@ namespace eosiosystem {
                 highest->high_bid > 0 &&
                 (current_time_point() - highest->last_bid_time) > microseconds(useconds_per_day) &&
                 _gstate.thresh_activated_stake_time > time_point() &&
-                (current_time_point() - _gstate.thresh_activated_stake_time) > microseconds(14 * useconds_per_day)){
+                (current_time_point() - _gstate.thresh_activated_stake_time) > microseconds(14*useconds_per_day)){
                _gstate.last_name_close = timestamp;
 
                checkbidname(highest, idx);

--- a/eosio.system/src/producer_pay.cpp
+++ b/eosio.system/src/producer_pay.cpp
@@ -3,7 +3,6 @@
 #include <eosio.token/eosio.token.hpp>
 
 #include <vector>
-
 namespace eosiosystem {
 
    const int64_t  min_pervote_daily_pay = 100'0000;
@@ -102,12 +101,10 @@ namespace eosiosystem {
          modifybid(names);
       };
       /// only update block producers once every minute, block_timestamp is in half seconds
-      if (timestamp.slot - _gstate.last_producer_schedule_update.slot > 120)
-      {
+      if (timestamp.slot - _gstate.last_producer_schedule_update.slot > 120) {
          update_elected_producers(timestamp);
 
-         if ((timestamp.slot - _gstate.last_name_close.slot) > blocks_per_day)
-         {
+         if ((timestamp.slot - _gstate.last_name_close.slot) > blocks_per_day){
             name_bid_table bids(_self, _self.value);
             auto idx = bids.get_index<"highbid"_n>();
             auto highest = idx.lower_bound(std::numeric_limits<uint64_t>::max() / 2);
@@ -115,12 +112,8 @@ namespace eosiosystem {
                 highest->high_bid > 0 &&
                 (current_time_point() - highest->last_bid_time) > microseconds(useconds_per_day) &&
                 _gstate.thresh_activated_stake_time > time_point() &&
-                (current_time_point() - _gstate.thresh_activated_stake_time) > microseconds(14 * useconds_per_day))
-            {
+                (current_time_point() - _gstate.thresh_activated_stake_time) > microseconds(14 * useconds_per_day)){
                _gstate.last_name_close = timestamp;
-               // idx.modify( highest, same_payer, [&]( auto& b ){
-               //    b.high_bid = -b.high_bid;
-               // });
 
                checkbidname(highest, idx);
             }

--- a/eosio.system/src/producer_pay.cpp
+++ b/eosio.system/src/producer_pay.cpp
@@ -52,11 +52,144 @@ namespace eosiosystem {
          });
       }
 
-      /// only update block producers once every minute, block_timestamp is in half seconds
-      if( timestamp.slot - _gstate.last_producer_schedule_update.slot > 120 ) {
-         update_elected_producers( timestamp );
 
-         if( (timestamp.slot - _gstate.last_name_close.slot) > blocks_per_day ) {
+      //bos  name length  category
+      boost::container::flat_map<uint8_t, uint8_t> biddeals;
+      boost::container::flat_map<uint8_t, uint8_t>::iterator itbiddeals;
+      uint16_t bitdeals=0;// 1111 1111 1000    1表示当前位对应短名长度的本次拍卖成交数达到上限
+      uint16_t bitdealed=0;// 1111 1111 1000    1表示当前位对应短名长度的本次有拍卖成交
+      uint16_t bitcloses=0;// 1111 1111 1000   1表示当前位对应短名长度的上次拍卖成功关闭时间未超过一天时间
+     
+          auto updateclose = [&](const auto &length) -> void {
+         bid_close_table closes_table(_self, _self.value);
+         auto it = closes_table.find(length);
+
+         if (it != closes_table.end()){
+             closes_table.modify( it, same_payer, [&]( auto& b ) {
+           b.last_name_close = timestamp;
+         });
+         }
+         
+      };
+      auto bidclose = [&](const auto &length) -> block_timestamp {
+         bid_close_table closes_table(_self, _self.value);
+         auto it = closes_table.find(length);
+
+         if (it != closes_table.end()){
+            return it->last_name_close;
+         }
+
+         return block_timestamp();
+      } ;
+       auto checkclosebylength = [&](auto &length) ->bool {
+       block_timestamp last_name_close = bidclose(length);
+         if ((timestamp.slot - last_name_close.slot) > blocks_per_day)
+         {
+            return true;
+         }
+
+         bitcloses |= 0x1<<length;
+
+         return false;
+
+      };
+
+      auto checkcloses = [&]() ->bool {
+         const int START_LENGTH = 3;
+         const int END_LENGTH=11;
+         for(int i=START_LENGTH;i<=END_LENGTH;i++)
+         {
+           checkclosebylength(i);
+         }
+
+         return 0xFF8!=(bitcloses&0xFF8);
+      };
+      
+
+
+   auto updatecloses = [&]() ->void {
+         const int START_LENGTH = 3;
+         const int END_LENGTH=11;
+         for(int i=START_LENGTH;i<=END_LENGTH;i++)
+         {
+         bool bidclose = checkclosebylength(i);//
+         bool dealed = (bitdealed&(0x1<<i)) != 0;
+         if(bidclose&&dealed){
+           updateclose(i);
+         }
+      }
+
+      };
+
+        auto checkdealbylength = [&](const auto &length) ->bool{
+     
+         uint8_t topn = length<=3?1:length;
+         uint8_t deals = 0;
+         itbiddeals = biddeals.find(length);
+
+         if(itbiddeals !=biddeals.end())
+         {
+            deals = itbiddeals->second;
+         }
+         else
+         {
+            biddeals[length]=deals;
+         }
+
+         if(deals>=topn)
+         {
+            bitdeals |= 0x1<<length;
+            return false;
+         }
+         
+         return true;
+      };
+
+         auto checkbidbylength = [&](auto &highest, auto &idx) {
+         if(highest == idx.end())
+         {
+            return;
+         }
+
+         do
+         {
+         uint8_t length = highest->newname.length();
+         length = length<=3?3:length;
+         block_timestamp last_name_close = bidclose(length);
+           
+         bool bidclose = checkclosebylength(length);
+         bool deal = checkdealbylength(length);
+        
+
+         if (bidclose&& deal&& highest->high_bid > 0 &&
+             (current_time_point() - highest->last_bid_time) > microseconds(useconds_per_day))
+         {
+          
+            idx.modify(highest, same_payer, [&](auto &b) {
+               b.high_bid = -b.high_bid;
+            });
+
+            biddeals[length]++;
+            bitdealed |= 0x1<<length;
+         }
+
+         if (0xFF8==(bitdeals&0xFF8))
+         {
+            break; //各个长度达到上限
+         }
+
+         highest++;
+         }while(highest!=idx.end());
+
+         updatecloses();
+      };
+
+   /// only update block producers once every minute, block_timestamp is in half seconds
+    if (timestamp.slot - _gstate.last_producer_schedule_update.slot > 120)
+      {
+         update_elected_producers( timestamp );
+         if( (timestamp.slot - _gstate.last_name_close.slot) > blocks_per_day && checkcloses()) {
+     
             name_bid_table bids(_self, _self.value);
             auto idx = bids.get_index<"highbid"_n>();
             auto highest = idx.lower_bound( std::numeric_limits<uint64_t>::max()/2 );
@@ -66,11 +199,14 @@ namespace eosiosystem {
                 _gstate.thresh_activated_stake_time > time_point() &&
                 (current_time_point() - _gstate.thresh_activated_stake_time) > microseconds(14 * useconds_per_day)
             ) {
-               _gstate.last_name_close = timestamp;
-               idx.modify( highest, same_payer, [&]( auto& b ){
-                  b.high_bid = -b.high_bid;
-               });
+               checkbidbylength(highest,idx);
+               // _gstate.last_name_close = timestamp;
+               // idx.modify( highest, same_payer, [&]( auto& b ){
+               //    b.high_bid = -b.high_bid;
+               // });
             }
+
+              _gstate.last_name_close = timestamp;
          }
       }
    }

--- a/eosio.system/src/producer_pay.cpp
+++ b/eosio.system/src/producer_pay.cpp
@@ -71,7 +71,7 @@ namespace eosiosystem {
          }
          std::vector<name> names;
          static const int16_t COUNT10 = 10;
-         static const int16_t BASE_LENGTH = 4;
+
          uint16_t deal_count = 0;
 
          if (highest->newname.length() >= BASE_LENGTH)

--- a/eosio.system/src/producer_pay.cpp
+++ b/eosio.system/src/producer_pay.cpp
@@ -1,6 +1,7 @@
 #include <eosio.system/eosio.system.hpp>
 
 #include <eosio.token/eosio.token.hpp>
+#include <string>
 
 namespace eosiosystem {
 
@@ -52,161 +53,156 @@ namespace eosiosystem {
          });
       }
 
-
+      ///bos begin
       //bos  name length  category
       boost::container::flat_map<uint8_t, uint8_t> biddeals;
       boost::container::flat_map<uint8_t, uint8_t>::iterator itbiddeals;
-      uint16_t bitdeals=0;// 1111 1111 1000    1表示当前位对应短名长度的本次拍卖成交数达到上限
-      uint16_t bitdealed=0;// 1111 1111 1000    1表示当前位对应短名长度的本次有拍卖成交
-      uint16_t bitcloses=0;// 1111 1111 1000   1表示当前位对应短名长度的上次拍卖成功关闭时间未超过一天时间
-     
-          auto updateclose = [&](const auto &length) -> void {
+      uint16_t bitdeals = 0;  // 1111 1111 1000    1表示当前位对应短名长度的本次拍卖成交数达到上限
+      uint16_t bitdealed = 0; // 1111 1111 1000    1表示当前位对应短名长度的本次有拍卖成交
+      uint16_t bitcloses = 0; // 1111 1111 1000   1表示当前位对应短名长度的上次拍卖成功关闭时间未超过一天时间
+
+      auto updateclose = [&](const auto &length) -> void {
          bid_close_table closes_table(_self, _self.value);
          auto it = closes_table.find(length);
 
-         if (it != closes_table.end()){
-             closes_table.modify( it, same_payer, [&]( auto& b ) {
-           b.last_name_close = timestamp;
-         });
+         if (it != closes_table.end())
+         {
+            closes_table.modify(it, same_payer, [&](auto &b) {
+               b.last_name_close = timestamp;
+            });
          }
-         
       };
       auto bidclose = [&](const auto &length) -> block_timestamp {
          bid_close_table closes_table(_self, _self.value);
          auto it = closes_table.find(length);
 
-         if (it != closes_table.end()){
+         if (it != closes_table.end())
+         {
             return it->last_name_close;
          }
 
          return block_timestamp();
-      } ;
-       auto checkclosebylength = [&](auto &length) ->bool {
-       block_timestamp last_name_close = bidclose(length);
+      };
+
+      auto checkclosebylength = [&](auto &length) -> bool {
+         block_timestamp last_name_close = bidclose(length);
          if ((timestamp.slot - last_name_close.slot) > blocks_per_day)
          {
             return true;
          }
 
-         bitcloses |= 0x1<<length;
+         bitcloses |= 0x1 << length;
 
          return false;
-
       };
 
-      auto checkcloses = [&]() ->bool {
+      auto checkcloses = [&]() -> bool {
          const int START_LENGTH = 3;
-         const int END_LENGTH=11;
-         for(int i=START_LENGTH;i<=END_LENGTH;i++)
+         const int END_LENGTH = 11;
+         for (int i = START_LENGTH; i <= END_LENGTH; i++)
          {
-           checkclosebylength(i);
+            checkclosebylength(i);
          }
 
-         return 0xFF8!=(bitcloses&0xFF8);
+         return 0xFF8 != (bitcloses & 0xFF8);
       };
-      
 
-
-   auto updatecloses = [&]() ->void {
+      auto updatecloses = [&]() -> void {
          const int START_LENGTH = 3;
-         const int END_LENGTH=11;
-         for(int i=START_LENGTH;i<=END_LENGTH;i++)
+         const int END_LENGTH = 11;
+         for (int i = START_LENGTH; i <= END_LENGTH; i++)
          {
-         bool bidclose = checkclosebylength(i);//
-         bool dealed = (bitdealed&(0x1<<i)) != 0;
-         if(bidclose&&dealed){
-           updateclose(i);
+            bool bidclose = checkclosebylength(i); //
+            bool dealed = (bitdealed & (0x1 << i)) != 0;
+            if (bidclose && dealed)
+            {
+               updateclose(i);
+            }
          }
-      }
-
       };
 
-        auto checkdealbylength = [&](const auto &length) ->bool{
-     
-         uint8_t topn = length<=3?1:length;
+      auto checkdealbylength = [&](const auto &length) -> bool {
+         uint8_t topn = length <= 3 ? 1 : length;
          uint8_t deals = 0;
          itbiddeals = biddeals.find(length);
 
-         if(itbiddeals !=biddeals.end())
+         if (itbiddeals != biddeals.end())
          {
             deals = itbiddeals->second;
          }
          else
          {
-            biddeals[length]=deals;
+            biddeals[length] = deals;
          }
 
-         if(deals>=topn)
+         if (deals >= topn)
          {
-            bitdeals |= 0x1<<length;
+            bitdeals |= 0x1 << length;
             return false;
          }
-         
+
          return true;
       };
 
-         auto checkbidbylength = [&](auto &highest, auto &idx) {
-         if(highest == idx.end())
+      auto checkbidbylength = [&](auto &highest, auto &idx) {
+         if (highest == idx.end())
          {
             return;
          }
 
          do
          {
-         uint8_t length = highest->newname.length();
-         length = length<=3?3:length;
-         block_timestamp last_name_close = bidclose(length);
-           
-         bool bidclose = checkclosebylength(length);
-         bool deal = checkdealbylength(length);
-        
+            uint8_t length = highest->newname.length();
+            length = length <= 3 ? 3 : length;
+            block_timestamp last_name_close = bidclose(length);
 
-         if (bidclose&& deal&& highest->high_bid > 0 &&
-             (current_time_point() - highest->last_bid_time) > microseconds(useconds_per_day))
-         {
-          
-            idx.modify(highest, same_payer, [&](auto &b) {
-               b.high_bid = -b.high_bid;
-            });
+            bool bidclose = checkclosebylength(length);
+            bool deal = checkdealbylength(length);
 
-            biddeals[length]++;
-            bitdealed |= 0x1<<length;
-         }
+            if (bidclose && deal && highest->high_bid > 0 &&
+                (current_time_point() - highest->last_bid_time) > microseconds(useconds_per_day))
+            {
+               idx.modify(highest, same_payer, [&](auto &b) {
+                  b.high_bid = -b.high_bid;
+               });
 
-         if (0xFF8==(bitdeals&0xFF8))
-         {
-            break; //各个长度达到上限
-         }
+               biddeals[length]++;
+               bitdealed |= 0x1 << length;
+            }
 
-         highest++;
-         }while(highest!=idx.end());
+            if (0xFF8 == (bitdeals & 0xFF8))
+            {
+               break; //各个长度达到上限
+            }
+
+            highest++;
+         } while (highest != idx.end());
 
          updatecloses();
       };
-
-   /// only update block producers once every minute, block_timestamp is in half seconds
-    if (timestamp.slot - _gstate.last_producer_schedule_update.slot > 120)
+      ///bos end
+      /// only update block producers once every minute, block_timestamp is in half seconds
+      if (timestamp.slot - _gstate.last_producer_schedule_update.slot > 120)
       {
-         update_elected_producers( timestamp );
-         if( (timestamp.slot - _gstate.last_name_close.slot) > blocks_per_day && checkcloses()) {
-     
+         update_elected_producers(timestamp);
+
+         ///  _gstate.last_name_close  is used for checking bid names per 24 hours
+         if (_gstate.thresh_activated_stake_time > time_point() &&
+             (current_time_point() - _gstate.thresh_activated_stake_time) > microseconds(14 * useconds_per_day) &&
+             (timestamp.slot - _gstate.last_name_close.slot) > blocks_per_day && checkcloses())
+         {
             name_bid_table bids(_self, _self.value);
             auto idx = bids.get_index<"highbid"_n>();
-            auto highest = idx.lower_bound( std::numeric_limits<uint64_t>::max()/2 );
-            if( highest != idx.end() &&
-                highest->high_bid > 0 &&
-                (current_time_point() - highest->last_bid_time) > microseconds(useconds_per_day) &&
-                _gstate.thresh_activated_stake_time > time_point() &&
-                (current_time_point() - _gstate.thresh_activated_stake_time) > microseconds(14 * useconds_per_day)
-            ) {
-               checkbidbylength(highest,idx);
-               // _gstate.last_name_close = timestamp;
-               // idx.modify( highest, same_payer, [&]( auto& b ){
-               //    b.high_bid = -b.high_bid;
-               // });
+            auto highest = idx.lower_bound(std::numeric_limits<uint64_t>::max() / 2);
+
+            //                (current_time_point() - highest->last_bid_time) > microseconds(useconds_per_day) &&
+            if (highest != idx.end() &&
+                highest->high_bid > 0)
+            {
+               checkbidbylength(highest, idx);
             }
 
-              _gstate.last_name_close = timestamp;
+            _gstate.last_name_close = timestamp;
          }
       }
    }

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -3075,38 +3075,6 @@ try
    BOOST_REQUIRE_EQUAL(success(), vote(N(carl), {N(producer)}));
 
    BOOST_REQUIRE_EQUAL(success(), buyram("bob", "bob", core_sym::from_string("300.0000")));
-   string namesubstr = "";
-   auto bidnamebylength = [&](const string &str) {
-      const string cstr = str;
-      BOOST_REQUIRE_EQUAL(success(),
-                          bidname("bob", name(cstr), core_sym::from_string("1.0000")));
-      int len = str.length();
-      for (int i = 0; i < len; i++)
-      {
-         namesubstr = cstr;
-         namesubstr += std::string(1, 'z' - i);
-         BOOST_REQUIRE_EQUAL(success(),
-                             bidname("bob", name(namesubstr), core_sym::from_string("1.1000")));
-         //bidname("bob", name(str + std::string(1,'z'-i)), core_sym::from_string("1.1000"));
-      }
-   };
-
-   // start bids
-   BOOST_REQUIRE_EQUAL(success(),
-                       bidname("bob", "a", core_sym::from_string("1.0001")));
-   BOOST_REQUIRE_EQUAL(success(),
-                       bidname("bob", "ab", core_sym::from_string("1.0002")));
-   BOOST_REQUIRE_EQUAL(success(),
-                       bidname("bob", "xyz", core_sym::from_string("1.0033")));
-   string basestr = "abcdefghijk";
-   BOOST_REQUIRE_EQUAL(success(),
-                       bidname("bob", name(basestr), core_sym::from_string("1.0000")));
-
-   for (int i = 3; i < basestr.length(); i++)
-   {
-      namesubstr = basestr.substr(0, i);
-      bidnamebylength(namesubstr);
-   }
 
    // BOOST_REQUIRE_EQUAL( core_sym::from_string( "9987.9981" ), get_balance("bob") );
 
@@ -3149,6 +3117,47 @@ try
    produce_blocks(2);
 
    produce_block();
+   string namesubstr = "";
+   auto bidnamebylength = [&](const string &str) {
+      const string cstr = str;
+      int len = str.length();
+      string symstr = "1.000";
+
+      symstr += std::to_string(len - 1);
+      BOOST_REQUIRE_EQUAL(success(),
+                          bidname("bob", name(cstr), core_sym::from_string(symstr)));
+      // for (int i = 0; i < len; i++)
+      // {
+      //    namesubstr = cstr;
+      //    namesubstr += std::string(1, 'z' - i);
+      //    BOOST_REQUIRE_EQUAL(success(),
+      //                        bidname("bob", name(namesubstr), core_sym::from_string("1.1000")));
+      //    //bidname("bob", name(str + std::string(1,'z'-i)), core_sym::from_string("1.1000"));
+      // }
+   };
+
+   // start bids
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", "a", core_sym::from_string("1.0000")));
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", "ab", core_sym::from_string("1.0000")));
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", "xyz", core_sym::from_string("2.0033")));
+   string basestr = "abcdefghijk";
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", name(basestr), core_sym::from_string("1.0010")));
+
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", "abab", core_sym::from_string("1.0001")));
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", "bcbc", core_sym::from_string("1.0002")));
+
+   for (int i = 4; i < basestr.length(); i++)
+   {
+      namesubstr = basestr.substr(0, i);
+      bidnamebylength(namesubstr);
+   }
+
    produce_block(fc::hours(24));
    // fc::mutable_variant_object obj = fc::mutable_variant_object()( "alice1111111","a" );
    //   REQUIRE_MATCHING_OBJECT( obj, get_name_bid( "a" ) );
@@ -3156,7 +3165,7 @@ try
 
    //   BOOST_TEST(0 == obj["high_bid"].as_double());
 
-   //   BOOST_TEST("1"==get_producer_info("producer")["url"].as_string());
+   BOOST_TEST("1" == get_producer_info("producer")["url"].as_string());
 
    //     BOOST_TEST(154==get_producer_info("producer")["location"].as<uint16_t>());
 
@@ -3165,34 +3174,148 @@ try
    auto createnamebylength = [&](const string &str) {
       const string cstr = str;
       int len = str.length();
-      for (int i = 0; i < len; i++)
+      // for (int i = 0; i < len; i++)
       {
          namesubstr = cstr;
-         namesubstr += std::string(1, 'z' - i);
-         // BOOST_TEST(""==namesubstr);
+         // namesubstr += std::string(1, 'z' - i);
+         BOOST_TEST("" == namesubstr);
          create_account_with_resources(name(namesubstr), N(bob));
       }
    };
 
-   // start bids
-   for (int i = 3; i < basestr.length(); i++)
+   for (int i = 4; i <= basestr.length(); i++)
    {
       namesubstr = basestr.substr(0, i);
       createnamebylength(namesubstr);
    }
 
-   for (int i = 1; i <= basestr.length(); i++)
-   {
-      // bool bb = !is_account( basestr.substr(0,i));
+   createnamebylength("abab");
+   createnamebylength("bcbc");
 
-      // BOOST_TEST(""==namesubstr);
+   createnamebylength("xyz");
+
+   BOOST_REQUIRE_EXCEPTION(create_account_with_resources(N(a), N(bob)),
+                           fc::exception, fc_assert_exception_message_is(not_closed_message));
+
+   ////=================================full great then four deal
+
+   // start bids
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", "uvw", core_sym::from_string("0.0033")));
+   basestr = "xbcdefghijk";
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", name(basestr), core_sym::from_string("1.0010")));
+
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", "xbab", core_sym::from_string("1.0001")));
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", "xcbc", core_sym::from_string("1.0002")));
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", "opqr", core_sym::from_string("1.0000")));
+   for (int i = 4; i < basestr.length(); i++)
+   {
       namesubstr = basestr.substr(0, i);
-      create_account_with_resources(namesubstr, N(bob));
-      //  BOOST_REQUIRE_EXCEPTION( create_account_with_resources( namesubstr, N(bob) ),
-      //                     fc::exception, fc_assert_exception_message_is( not_closed_message ) );
-      // BOOST_REQUIRE_EXCEPTION( create_accounts_with_resources( { name(namesubstr) }, N(bob) ), // bob shouldn't be able to create fail
-      //                    eosio_assert_message_exception, eosio_assert_message_is( "no active bid for name" ) );
+      bidnamebylength(namesubstr);
    }
+
+   produce_block(fc::hours(24));
+   // fc::mutable_variant_object obj = fc::mutable_variant_object()( "alice1111111","a" );
+   //   REQUIRE_MATCHING_OBJECT( obj, get_name_bid( "a" ) );
+   //    auto obj = get_name_bid("a") ;
+
+   //   BOOST_TEST(0 == obj["high_bid"].as_double());
+
+   BOOST_TEST("1" == get_producer_info("producer")["url"].as_string());
+
+   //     BOOST_TEST(154==get_producer_info("producer")["location"].as<uint16_t>());
+
+   // by now bid for ae has closed
+
+   for (int i = 4; i <= basestr.length(); i++)
+   {
+      namesubstr = basestr.substr(0, i);
+      createnamebylength(namesubstr);
+   }
+
+   createnamebylength("xbab");
+   createnamebylength("xcbc");
+
+   // createnamebylength("uvw");
+
+   BOOST_REQUIRE_EXCEPTION(create_account_with_resources(N(uvw), N(bob)),
+                           fc::exception, fc_assert_exception_message_is(not_closed_message));
+
+   BOOST_REQUIRE_EXCEPTION(create_account_with_resources(N(opqr), N(bob)),
+                           fc::exception, fc_assert_exception_message_is(not_closed_message));
+
+   ////=================================full less then four deal
+
+   // start bids
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", "rst", core_sym::from_string("3.0033")));
+   basestr = "ybcdefghijk";
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", "opq", core_sym::from_string("1.0010")));
+
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", "ybab", core_sym::from_string("1.0001")));
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", "ycbc", core_sym::from_string("1.0001")));
+
+   for (int i = 0; i < basestr.length() - 2; i++)
+   {
+      namesubstr = basestr.substr(i, 3);
+      bidnamebylength(namesubstr);
+   }
+
+   produce_block(fc::hours(24));
+   // fc::mutable_variant_object obj = fc::mutable_variant_object()( "alice1111111","a" );
+   //   REQUIRE_MATCHING_OBJECT( obj, get_name_bid( "a" ) );
+   //    auto obj = get_name_bid("a") ;
+
+   //   BOOST_TEST(0 == obj["high_bid"].as_double());
+
+   BOOST_TEST("1" == get_producer_info("producer")["url"].as_string());
+
+   //     BOOST_TEST(154==get_producer_info("producer")["location"].as<uint16_t>());
+
+   // by now bid for ae has closed
+
+   createnamebylength("rst");
+   for (int i = 0; i < basestr.length() - 2; i++)
+   {
+      namesubstr = basestr.substr(i, 3);
+      BOOST_TEST("" == namesubstr);
+      BOOST_REQUIRE_EXCEPTION(create_account_with_resources(name(namesubstr), N(bob)),
+                              fc::exception, fc_assert_exception_message_is(not_closed_message));
+   }
+
+   BOOST_TEST("" == "opq");
+   BOOST_REQUIRE_EXCEPTION(create_account_with_resources(N(opq), N(bob)),
+                           fc::exception, fc_assert_exception_message_is(not_closed_message));
+
+   BOOST_TEST("" == "ycbc");
+   BOOST_REQUIRE_EXCEPTION(create_account_with_resources(N(ycbc), N(bob)),
+                           fc::exception, fc_assert_exception_message_is(not_closed_message));
+
+   // createnamebylength("uvw");
+
+   BOOST_TEST("" == "ybab");
+   BOOST_REQUIRE_EXCEPTION(create_account_with_resources(N(ybab), N(bob)),
+                           fc::exception, fc_assert_exception_message_is(not_closed_message));
+
+   // for (int i = 1; i <= basestr.length(); i++)
+   // {
+   //    // bool bb = !is_account( basestr.substr(0,i));
+
+   //    // BOOST_TEST(""==namesubstr);
+   //    namesubstr = basestr.substr(0, i);
+   //    // create_account_with_resources(namesubstr, N(bob));
+   //     BOOST_REQUIRE_EXCEPTION( create_account_with_resources( namesubstr, N(bob) ),
+   //                        fc::exception, fc_assert_exception_message_is( not_closed_message ) );
+   //    // BOOST_REQUIRE_EXCEPTION( create_accounts_with_resources( { name(namesubstr) }, N(bob) ), // bob shouldn't be able to create fail
+   //    //                    eosio_assert_message_exception, eosio_assert_message_is( "no active bid for name" ) );
+   // }
 
    // ae can now create *.ae
    // BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(xyz.ae), N(carl) ),

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -3056,7 +3056,7 @@ try
 {
 
    const std::string not_closed_message("auction for name is not closed yet");
-   const std::string bid10_message("newname which length is less than 3  must increase bid by 10% than highest bid in all bid ");
+   const std::string bid10_message("newname which length is less than 3  must increase bid by 10% than highest bid in all bid");
 
    std::vector<account_name> accounts = {N(alice), N(bob), N(carl), N(david), N(eve)};
    create_accounts_with_resources(accounts);
@@ -3083,16 +3083,27 @@ try
    // bidname( "carl", "ae", core_sym::from_string("1.0000") );
 
    BOOST_REQUIRE_EQUAL(success(),
-                       bidname("bob", "eosio", core_sym::from_string("0.0100")));
+                       bidname("bob", "eosi", core_sym::from_string("1.0100")));
+   produce_block();
+   BOOST_TEST("" == "fos");
 
-   BOOST_REQUIRE_EXCEPTION(bidname("bob", "eos", core_sym::from_string("0.0101")),
-                           fc::exception, fc_assert_exception_message_is(bid10_message));
+   BOOST_CHECK_EQUAL(success(),
+                       bidname("bob", "fos", core_sym::from_string("1.0101")));
 
-   BOOST_REQUIRE_EQUAL(success(),
-                       bidname("bob", "io", core_sym::from_string("0.1000")));
-
-   BOOST_REQUIRE_EXCEPTION(bidname("bob", "bp", core_sym::from_string("0.1020")),
-                           fc::exception, fc_assert_exception_message_is(bid10_message));
+   produce_block();
+       BOOST_TEST("" == "esi");
+   BOOST_CHECK_EQUAL(success(),
+                       bidname("bob", "esi", core_sym::from_string("1.0100")));
+   BOOST_TEST("" == "eoseos");
+   BOOST_TEST("2" == get_producer_info("producer")["url"].as_string());
+   BOOST_CHECK_EQUAL(success(),
+                       bidname("bob", "eoseos", core_sym::from_string("1.0100")));
+   BOOST_TEST("" == "io");
+   BOOST_CHECK_EQUAL(success(),
+                       bidname("bob", "io", core_sym::from_string("3.1000")));
+   BOOST_TEST("" == "bp");
+   BOOST_CHECK_EQUAL(success(),
+                       bidname("bob", "bp", core_sym::from_string("1.0100")));
 
    produce_block(fc::days(14));
    produce_block();

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -5,6 +5,7 @@
 #include <eosio/chain/wast_to_wasm.hpp>
 #include <cstdlib>
 #include <iostream>
+#include <string>
 #include <fc/log/logger.hpp>
 #include <eosio/chain/exceptions.hpp>
 #include <Runtime/Runtime.h>
@@ -2897,7 +2898,7 @@ BOOST_FIXTURE_TEST_CASE( bid_invalid_names, eosio_system_tester ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
-
+ 
    const std::string not_closed_message("auction for name is not closed yet");
 
    std::vector<account_name> accounts = { N(alice), N(bob), N(carl), N(david), N(eve) };
@@ -2917,7 +2918,7 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( success(), vote( N(carl), { N(producer) } ) );
 
    // start bids
-   bidname( "bob",  "prefa", core_sym::from_string("1.0003") );
+   bidname( "bob",  "a", core_sym::from_string("1.0003") );
    BOOST_REQUIRE_EQUAL( core_sym::from_string( "9998.9997" ), get_balance("bob") );
    bidname( "bob",  "prefb", core_sym::from_string("1.0000") );
    bidname( "bob",  "prefc", core_sym::from_string("1.0000") );
@@ -2969,7 +2970,7 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
 
    // stake enough to go above the 15% threshold
    stake_with_transfer( config::system_account_name, "alice", core_sym::from_string( "10000000.0000" ), core_sym::from_string( "10000000.0000" ) );
-   BOOST_REQUIRE_EQUAL(0, get_producer_info("producer")["unpaid_blocks"].as<uint32_t>());
+   BOOST_REQUIRE_EQUAL(9, get_producer_info("producer")["unpaid_blocks"].as<uint32_t>());
    BOOST_REQUIRE_EQUAL( success(), vote( N(alice), { N(producer) } ) );
 
    // need to wait for 14 days after going live
@@ -2983,7 +2984,7 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
    create_account_with_resources( N(prefd), N(david) );
    produce_blocks(2);
    produce_block( fc::hours(23) );
-   // auctions for prefa, prefb, prefc, prefe haven't been closed
+   // auctions for a, prefb, prefc, prefe haven't been closed
    BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefa), N(bob) ),
                             fc::exception, fc_assert_exception_message_is( not_closed_message ) );
    BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefb), N(alice) ),
@@ -3048,6 +3049,163 @@ BOOST_FIXTURE_TEST_CASE( namebid_pending_winner, eosio_system_tester ) try {
    //despite "perfa" account hasn't been created, we should be able to create "perfb" account
    create_account_with_resources( N(prefb), N(bob111111111) );
 } FC_LOG_AND_RETHROW()
+
+///bos begin=====================================
+BOOST_FIXTURE_TEST_CASE(multiple_namebidsbylength, eosio_system_tester)
+try
+{
+
+   const std::string not_closed_message("auction for name is not closed yet");
+
+   std::vector<account_name> accounts = {N(alice), N(bob), N(carl), N(david), N(eve)};
+   create_accounts_with_resources(accounts);
+   for (const auto &a : accounts)
+   {
+      transfer(config::system_account_name, a, core_sym::from_string("10000.0000"));
+      BOOST_REQUIRE_EQUAL(core_sym::from_string("10000.0000"), get_balance(a));
+   }
+   create_accounts_with_resources({N(producer)});
+   BOOST_REQUIRE_EQUAL(success(), regproducer(N(producer)));
+
+   produce_block();
+   // stake but but not enough to go live
+   stake_with_transfer(config::system_account_name, "bob", core_sym::from_string("55000000.0000"), core_sym::from_string("55000000.0000"));
+   stake_with_transfer(config::system_account_name, "carl", core_sym::from_string("35000000.0000"), core_sym::from_string("35000000.0000"));
+   BOOST_REQUIRE_EQUAL(success(), vote(N(bob), {N(producer)}));
+   BOOST_REQUIRE_EQUAL(success(), vote(N(carl), {N(producer)}));
+
+   BOOST_REQUIRE_EQUAL(success(), buyram("bob", "bob", core_sym::from_string("300.0000")));
+   string namesubstr = "";
+   auto bidnamebylength = [&](const string &str) {
+      const string cstr = str;
+      BOOST_REQUIRE_EQUAL(success(),
+                          bidname("bob", name(cstr), core_sym::from_string("1.0000")));
+      int len = str.length();
+      for (int i = 0; i < len; i++)
+      {
+         namesubstr = cstr;
+         namesubstr += std::string(1, 'z' - i);
+         BOOST_REQUIRE_EQUAL(success(),
+                             bidname("bob", name(namesubstr), core_sym::from_string("1.1000")));
+         //bidname("bob", name(str + std::string(1,'z'-i)), core_sym::from_string("1.1000"));
+      }
+   };
+
+   // start bids
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", "a", core_sym::from_string("1.0001")));
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", "ab", core_sym::from_string("1.0002")));
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", "xyz", core_sym::from_string("1.0033")));
+   string basestr = "abcdefghijk";
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", name(basestr), core_sym::from_string("1.0000")));
+
+   for (int i = 3; i < basestr.length(); i++)
+   {
+      namesubstr = basestr.substr(0, i);
+      bidnamebylength(namesubstr);
+   }
+
+   // BOOST_REQUIRE_EQUAL( core_sym::from_string( "9987.9981" ), get_balance("bob") );
+
+   // bidname( "carl", "ad", core_sym::from_string("1.0000") );
+   // bidname( "carl", "ae", core_sym::from_string("1.0000") );
+
+   produce_block(fc::days(14));
+   produce_block();
+
+   // highest bid is from david for ad but no bids can be closed yet
+   // BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(ad), N(david) ),
+   //                          fc::exception, fc_assert_exception_message_is( not_closed_message ) );
+
+   // stake enough to go above the 15% threshold
+   stake_with_transfer(config::system_account_name, "alice", core_sym::from_string("10000000.0000"), core_sym::from_string("10000000.0000"));
+   // BOOST_TEST(15==get_producer_info("producer")["unpaid_blocks"].as<uint32_t>());
+   BOOST_REQUIRE_EQUAL(success(), vote(N(alice), {N(producer)}));
+
+   // need to wait for 14 days after going live
+   produce_blocks(10);
+   produce_block(fc::days(2));
+   produce_blocks(10);
+   // BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(ad), N(david) ),
+   //                          fc::exception, fc_assert_exception_message_is( not_closed_message ) );
+   // it's been 14 days, auction for ad has been closed
+   produce_block(fc::days(12));
+   // create_account_with_resources( N(ad), N(david) );
+   produce_blocks(2);
+   produce_block(fc::hours(23));
+   // auctions for a, ab, ac, ae haven't been closed
+
+   produce_block(fc::hours(22));
+   produce_blocks(2);
+   // BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(ab), N(eve) ),
+   //                          fc::exception, fc_assert_exception_message_is( not_closed_message ) );
+   // but changing a bid that is not the highest does not push closing time
+   // BOOST_REQUIRE_EQUAL( success(),
+   //                      bidname( "carl", "ae", core_sym::from_string("2.0980") ) );
+   produce_block(fc::hours(2));
+   produce_blocks(2);
+
+   produce_block();
+   produce_block(fc::hours(24));
+   // fc::mutable_variant_object obj = fc::mutable_variant_object()( "alice1111111","a" );
+   //   REQUIRE_MATCHING_OBJECT( obj, get_name_bid( "a" ) );
+   //    auto obj = get_name_bid("a") ;
+
+   //   BOOST_TEST(0 == obj["high_bid"].as_double());
+
+   //   BOOST_TEST("1"==get_producer_info("producer")["url"].as_string());
+
+   //     BOOST_TEST(154==get_producer_info("producer")["location"].as<uint16_t>());
+
+   // by now bid for ae has closed
+
+   auto createnamebylength = [&](const string &str) {
+      const string cstr = str;
+      int len = str.length();
+      for (int i = 0; i < len; i++)
+      {
+         namesubstr = cstr;
+         namesubstr += std::string(1, 'z' - i);
+         // BOOST_TEST(""==namesubstr);
+         create_account_with_resources(name(namesubstr), N(bob));
+      }
+   };
+
+   // start bids
+   for (int i = 3; i < basestr.length(); i++)
+   {
+      namesubstr = basestr.substr(0, i);
+      createnamebylength(namesubstr);
+   }
+
+   for (int i = 1; i <= basestr.length(); i++)
+   {
+      // bool bb = !is_account( basestr.substr(0,i));
+
+      // BOOST_TEST(""==namesubstr);
+      namesubstr = basestr.substr(0, i);
+      create_account_with_resources(namesubstr, N(bob));
+      //  BOOST_REQUIRE_EXCEPTION( create_account_with_resources( namesubstr, N(bob) ),
+      //                     fc::exception, fc_assert_exception_message_is( not_closed_message ) );
+      // BOOST_REQUIRE_EXCEPTION( create_accounts_with_resources( { name(namesubstr) }, N(bob) ), // bob shouldn't be able to create fail
+      //                    eosio_assert_message_exception, eosio_assert_message_is( "no active bid for name" ) );
+   }
+
+   // ae can now create *.ae
+   // BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(xyz.ae), N(carl) ),
+   //                          fc::exception, fc_assert_exception_message_is("only suffix may create this account") );
+   // transfer( config::system_account_name, N(ae), core_sym::from_string("10000.0000") );
+   // create_account_with_resources( N(xyz.ae), N(ae) );
+
+   // other auctions haven't closed
+   // BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(a), N(bob) ),
+   //                          fc::exception, fc_assert_exception_message_is( not_closed_message ) );
+}
+FC_LOG_AND_RETHROW()
+///bos end=====================================
 
 BOOST_FIXTURE_TEST_CASE( vote_producers_in_and_out, eosio_system_tester ) try {
 

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -3121,9 +3121,9 @@ try
    auto bidnamebylength = [&](const string &str) {
       const string cstr = str;
       int len = str.length();
-      string symstr = "1.000";
+      string symstr = "1.";
 
-      symstr += std::to_string(len - 1);
+      symstr += std::to_string(len - 1)+"000";
       BOOST_REQUIRE_EQUAL(success(),
                           bidname("bob", name(cstr), core_sym::from_string(symstr)));
       // for (int i = 0; i < len; i++)
@@ -3140,9 +3140,9 @@ try
    BOOST_REQUIRE_EQUAL(success(),
                        bidname("bob", "a", core_sym::from_string("1.0000")));
    BOOST_REQUIRE_EQUAL(success(),
-                       bidname("bob", "ab", core_sym::from_string("1.0000")));
+                       bidname("bob", "ab", core_sym::from_string("2.0000")));
    BOOST_REQUIRE_EQUAL(success(),
-                       bidname("bob", "xyz", core_sym::from_string("2.0033")));
+                       bidname("bob", "xyz", core_sym::from_string("3.0033")));
    string basestr = "abcdefghijk";
    BOOST_REQUIRE_EQUAL(success(),
                        bidname("bob", name(basestr), core_sym::from_string("1.0010")));
@@ -3201,7 +3201,7 @@ try
 
    // start bids
    BOOST_REQUIRE_EQUAL(success(),
-                       bidname("bob", "uvw", core_sym::from_string("0.0033")));
+                       bidname("bob", "uvw", core_sym::from_string("10.0033")));
    basestr = "xbcdefghijk";
    BOOST_REQUIRE_EQUAL(success(),
                        bidname("bob", name(basestr), core_sym::from_string("1.0010")));
@@ -3255,7 +3255,7 @@ try
                        bidname("bob", "rst", core_sym::from_string("3.0033")));
    basestr = "ybcdefghijk";
    BOOST_REQUIRE_EQUAL(success(),
-                       bidname("bob", "opq", core_sym::from_string("1.0010")));
+                       bidname("bob", "opq", core_sym::from_string("4.0010")));
 
    BOOST_REQUIRE_EQUAL(success(),
                        bidname("bob", "ybab", core_sym::from_string("1.0001")));

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -2898,8 +2898,7 @@ BOOST_FIXTURE_TEST_CASE( bid_invalid_names, eosio_system_tester ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
- 
-   const std::string not_closed_message("auction for name is not closed yet");
+    const std::string not_closed_message("auction for name is not closed yet");
 
    std::vector<account_name> accounts = { N(alice), N(bob), N(carl), N(david), N(eve) };
    create_accounts_with_resources( accounts );
@@ -2918,7 +2917,7 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( success(), vote( N(carl), { N(producer) } ) );
 
    // start bids
-   bidname( "bob",  "a", core_sym::from_string("1.0003") );
+   bidname( "bob",  "prefa", core_sym::from_string("1.0003") );
    BOOST_REQUIRE_EQUAL( core_sym::from_string( "9998.9997" ), get_balance("bob") );
    bidname( "bob",  "prefb", core_sym::from_string("1.0000") );
    bidname( "bob",  "prefc", core_sym::from_string("1.0000") );
@@ -2970,7 +2969,7 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
 
    // stake enough to go above the 15% threshold
    stake_with_transfer( config::system_account_name, "alice", core_sym::from_string( "10000000.0000" ), core_sym::from_string( "10000000.0000" ) );
-   BOOST_REQUIRE_EQUAL(9, get_producer_info("producer")["unpaid_blocks"].as<uint32_t>());
+   BOOST_REQUIRE_EQUAL(0, get_producer_info("producer")["unpaid_blocks"].as<uint32_t>());
    BOOST_REQUIRE_EQUAL( success(), vote( N(alice), { N(producer) } ) );
 
    // need to wait for 14 days after going live
@@ -2984,7 +2983,7 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
    create_account_with_resources( N(prefd), N(david) );
    produce_blocks(2);
    produce_block( fc::hours(23) );
-   // auctions for a, prefb, prefc, prefe haven't been closed
+   // auctions for prefa prefb, prefc, prefe haven't been closed
    BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefa), N(bob) ),
                             fc::exception, fc_assert_exception_message_is( not_closed_message ) );
    BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefb), N(alice) ),

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -2898,7 +2898,7 @@ BOOST_FIXTURE_TEST_CASE( bid_invalid_names, eosio_system_tester ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
-   
+
    const std::string not_closed_message("auction for name is not closed yet");
 
    std::vector<account_name> accounts = { N(alice), N(bob), N(carl), N(david), N(eve) };

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -3112,8 +3112,8 @@ try
    // BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(ad), N(david) ),
    //                          fc::exception, fc_assert_exception_message_is( not_closed_message ) );
 
-BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(ad), N(david) ),
-                             fc::exception, fc_assert_exception_message_is( bid10_message ) );
+// BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(ad), N(david) ),
+//                              fc::exception, fc_assert_exception_message_is( bid10_message ) );
 
    // stake enough to go above the 15% threshold
    stake_with_transfer(config::system_account_name, "alice", core_sym::from_string("10000000.0000"), core_sym::from_string("10000000.0000"));
@@ -3145,13 +3145,17 @@ BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(ad), N(david) ),
 
    produce_block();
    string namesubstr = "";
+    uint64_t percent =10;
    auto bidnamebylength = [&](const string &str) {
       const string cstr = str;
       int len = str.length();
+      BOOST_TEST("" ==  std::to_string(len));
       string symstr = "1.";
-
-      symstr += std::to_string(len - 1)+"000";
-      BOOST_REQUIRE_EQUAL(success(),
+      percent = 10;
+      std::string strp = std::to_string(percent)+"00000";
+      symstr += strp.substr(0,4);
+      BOOST_TEST("" == str);
+      BOOST_CHECK_EQUAL(success(),
                           bidname("bob", name(cstr), core_sym::from_string(symstr)));
       // for (int i = 0; i < len; i++)
       // {
@@ -3163,11 +3167,14 @@ BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(ad), N(david) ),
       // }
    };
 
+ 
+
+
    // start bids
    BOOST_REQUIRE_EQUAL(success(),
-                       bidname("bob", "a", core_sym::from_string("1.0000")));
+                       bidname("bob", "a", core_sym::from_string("0.0001")));
    BOOST_REQUIRE_EQUAL(success(),
-                       bidname("bob", "ab", core_sym::from_string("2.0000")));
+                       bidname("bob", "ab", core_sym::from_string("0.0011")));
    BOOST_REQUIRE_EQUAL(success(),
                        bidname("bob", "xyz", core_sym::from_string("3.0033")));
    string basestr = "abcdefghijk";
@@ -3206,7 +3213,7 @@ BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(ad), N(david) ),
          namesubstr = cstr;
          // namesubstr += std::string(1, 'z' - i);
          BOOST_TEST("" == namesubstr);
-         create_account_with_resources(name(namesubstr), N(bob));
+         BOOST_CHECK_EQUAL(nullptr,create_account_with_resources(name(namesubstr), N(bob)) );
       }
    };
 
@@ -3216,28 +3223,32 @@ BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(ad), N(david) ),
       createnamebylength(namesubstr);
    }
 
-   createnamebylength("abab");
-   createnamebylength("bcbc");
+   // createnamebylength("abab");
+   // createnamebylength("bcbc");
+   // BOOST_REQUIRE_EXCEPTION(create_account_with_resources(N(a), N(bob)),
+   //                         fc::exception, fc_assert_exception_message_is(not_closed_message));
 
    createnamebylength("xyz");
 
-   BOOST_REQUIRE_EXCEPTION(create_account_with_resources(N(a), N(bob)),
-                           fc::exception, fc_assert_exception_message_is(not_closed_message));
+   // BOOST_REQUIRE_EXCEPTION(create_account_with_resources(N(a), N(bob)),
+   //                         fc::exception, fc_assert_exception_message_is(not_closed_message));
 
    ////=================================full great then four deal
 
    // start bids
-   BOOST_REQUIRE_EQUAL(success(),
-                       bidname("bob", "uvw", core_sym::from_string("10.0033")));
-   basestr = "xbcdefghijk";
-   BOOST_REQUIRE_EQUAL(success(),
+    basestr = "xbcdefghijk";
+
+   BOOST_CHECK_EQUAL(success(),
+                       bidname("bob", "uvw", core_sym::from_string("1.0033")));
+  
+   BOOST_CHECK_EQUAL(success(),
                        bidname("bob", name(basestr), core_sym::from_string("1.0010")));
 
-   BOOST_REQUIRE_EQUAL(success(),
+   BOOST_CHECK_EQUAL(success(),
                        bidname("bob", "xbab", core_sym::from_string("1.0001")));
-   BOOST_REQUIRE_EQUAL(success(),
+   BOOST_CHECK_EQUAL(success(),
                        bidname("bob", "xcbc", core_sym::from_string("1.0002")));
-   BOOST_REQUIRE_EQUAL(success(),
+   BOOST_CHECK_EQUAL(success(),
                        bidname("bob", "opqr", core_sym::from_string("1.0000")));
    for (int i = 4; i < basestr.length(); i++)
    {
@@ -3264,36 +3275,56 @@ BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(ad), N(david) ),
       createnamebylength(namesubstr);
    }
 
-   createnamebylength("xbab");
-   createnamebylength("xcbc");
+   // createnamebylength("xbab");
+   // createnamebylength("xcbc");
 
    // createnamebylength("uvw");
 
-   BOOST_REQUIRE_EXCEPTION(create_account_with_resources(N(uvw), N(bob)),
-                           fc::exception, fc_assert_exception_message_is(not_closed_message));
+   // BOOST_REQUIRE_EXCEPTION(create_account_with_resources(N(uvw), N(bob)),
+   //                         fc::exception, fc_assert_exception_message_is(not_closed_message));
 
-   BOOST_REQUIRE_EXCEPTION(create_account_with_resources(N(opqr), N(bob)),
-                           fc::exception, fc_assert_exception_message_is(not_closed_message));
+   // BOOST_REQUIRE_EXCEPTION(create_account_with_resources(N(opqr), N(bob)),
+   //                         fc::exception, fc_assert_exception_message_is(not_closed_message));
 
    ////=================================full less then four deal
 
    // start bids
-   BOOST_REQUIRE_EQUAL(success(),
-                       bidname("bob", "rst", core_sym::from_string("3.0033")));
    basestr = "ybcdefghijk";
-   BOOST_REQUIRE_EQUAL(success(),
-                       bidname("bob", "opq", core_sym::from_string("4.0010")));
+  
+   BOOST_CHECK_EQUAL(success(),
+                       bidname("bob", "ybab", core_sym::from_string("0.0001")));
+   BOOST_CHECK_EQUAL(success(),
+                       bidname("bob", "ycbc", core_sym::from_string("0.0001")));
 
-   BOOST_REQUIRE_EQUAL(success(),
-                       bidname("bob", "ybab", core_sym::from_string("1.0001")));
-   BOOST_REQUIRE_EQUAL(success(),
-                       bidname("bob", "ycbc", core_sym::from_string("1.0001")));
+  uint64_t percentx =2000000;
+   auto bidnamebylengthx = [&](const string &str) {
+      const string cstr = str;
+      int len = str.length();
+      BOOST_TEST("" ==  std::to_string(len));
+      string symstr = "2.";
+      percentx = percentx*1200/1000000;
+      std::string strp = std::to_string(percentx-20000)+"00000";
+      symstr += strp.substr(0,4);
+      BOOST_TEST("" == str);
+      BOOST_TEST("" == symstr);
+      BOOST_CHECK_EQUAL(success(),
+                          bidname("bob", name(cstr), core_sym::from_string(symstr)));
+ 
+   };
 
    for (int i = 0; i < basestr.length() - 2; i++)
    {
       namesubstr = basestr.substr(i, 3);
-      bidnamebylength(namesubstr);
+      bidnamebylengthx(namesubstr);
    }
+
+   BOOST_TEST("1" == "rst");
+   BOOST_CHECK_EQUAL(success(),
+                     bidname("bob", "rst", core_sym::from_string("2.0033")));
+
+   BOOST_TEST("1" == "opq");
+   BOOST_CHECK_EQUAL(success(),
+                       bidname("bob", "opq", core_sym::from_string("4.0110")));
 
    produce_block(fc::hours(24));
    // fc::mutable_variant_object obj = fc::mutable_variant_object()( "alice1111111","a" );

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -3056,6 +3056,7 @@ try
 {
 
    const std::string not_closed_message("auction for name is not closed yet");
+   const std::string bid10_message("newname which length is less than 3  must increase bid by 10% than highest bid in all bid ");
 
    std::vector<account_name> accounts = {N(alice), N(bob), N(carl), N(david), N(eve)};
    create_accounts_with_resources(accounts);
@@ -3081,12 +3082,27 @@ try
    // bidname( "carl", "ad", core_sym::from_string("1.0000") );
    // bidname( "carl", "ae", core_sym::from_string("1.0000") );
 
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", "eosio", core_sym::from_string("0.0100")));
+
+   BOOST_REQUIRE_EXCEPTION(bidname("bob", "eos", core_sym::from_string("0.0101")),
+                           fc::exception, fc_assert_exception_message_is(bid10_message));
+
+   BOOST_REQUIRE_EQUAL(success(),
+                       bidname("bob", "io", core_sym::from_string("0.1000")));
+
+   BOOST_REQUIRE_EXCEPTION(bidname("bob", "bp", core_sym::from_string("0.1020")),
+                           fc::exception, fc_assert_exception_message_is(bid10_message));
+
    produce_block(fc::days(14));
    produce_block();
 
    // highest bid is from david for ad but no bids can be closed yet
    // BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(ad), N(david) ),
    //                          fc::exception, fc_assert_exception_message_is( not_closed_message ) );
+
+BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(ad), N(david) ),
+                             fc::exception, fc_assert_exception_message_is( bid10_message ) );
 
    // stake enough to go above the 15% threshold
    stake_with_transfer(config::system_account_name, "alice", core_sym::from_string("10000000.0000"), core_sym::from_string("10000000.0000"));
@@ -3303,6 +3319,10 @@ try
    BOOST_TEST("" == "ybab");
    BOOST_REQUIRE_EXCEPTION(create_account_with_resources(N(ybab), N(bob)),
                            fc::exception, fc_assert_exception_message_is(not_closed_message));
+
+
+
+
 
    // for (int i = 1; i <= basestr.length(); i++)
    // {

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -2898,7 +2898,8 @@ BOOST_FIXTURE_TEST_CASE( bid_invalid_names, eosio_system_tester ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
-    const std::string not_closed_message("auction for name is not closed yet");
+   
+   const std::string not_closed_message("auction for name is not closed yet");
 
    std::vector<account_name> accounts = { N(alice), N(bob), N(carl), N(david), N(eve) };
    create_accounts_with_resources( accounts );
@@ -2983,7 +2984,7 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
    create_account_with_resources( N(prefd), N(david) );
    produce_blocks(2);
    produce_block( fc::hours(23) );
-   // auctions for prefa prefb, prefc, prefe haven't been closed
+   // auctions for prefa, prefb, prefc, prefe haven't been closed
    BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefa), N(bob) ),
                             fc::exception, fc_assert_exception_message_is( not_closed_message ) );
    BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefb), N(alice) ),


### PR DESCRIPTION
实现问题#11 
* 根据短名长度分组级别（<4为一组，其他长度为一组）。 同一长度按出价排名；
* 排名竞拍价由高到低前11个 ，长度<4只在每次出价最高者成交，<4不是出价最高，本次不成交。
前11个中 取>4成交，最多10个。