### PR TITLE
add new contract: personal.bos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ add_subdirectory(eosio.system)
 add_subdirectory(eosio.token)
 add_subdirectory(bos.pegtoken)
 add_subdirectory(redpacket)
+add_subdirectory(personal.bos)
 
 
 if (APPLE)

--- a/personal.bos/CMakeLists.txt
+++ b/personal.bos/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_contract(personal.bos personal.bos ${CMAKE_CURRENT_SOURCE_DIR}/src/personal.bos.cpp)
+target_include_directories(personal.bos.wasm
+   PUBLIC
+   ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+set_target_properties(personal.bos.wasm
+   PROPERTIES
+   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")

--- a/personal.bos/README.md
+++ b/personal.bos/README.md
@@ -1,0 +1,13 @@
+personal.bos
+-----------
+
+This bos contract allows users to maintain personal data
+actions:
+void setpersonal(name account,string key,string value);
+void sethomepage(name account,string url);
+
+it's a simple key-value map.
+sethomepage actually calls setpersonal, just set key to "homepage".
+by supplying homepage, dapp can guide users to their homepage.
+
+

--- a/personal.bos/include/personal.bos/personal.bos.hpp
+++ b/personal.bos/include/personal.bos/personal.bos.hpp
@@ -1,0 +1,56 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
+#pragma once
+
+#include <eosiolib/eosio.hpp>
+
+#include <string>
+
+namespace eosio {
+
+   using std::string;
+
+   class [[eosio::contract("personal.bos")]] personal_contract : public contract {
+      public:
+         using contract::contract;
+
+         [[eosio::action]]
+         void setpersonal( name account, string key, string value);
+
+         [[eosio::action]]
+         void sethomepage( name account, string url);
+
+         string get_personal( name account, string key ){
+            if(key.size() > 12){
+               return "";
+            }
+            name key_name{ std::string_view(key) };
+            personal_table personal( _self , account.value );
+            auto ite = personal.find( key_name.value );
+            if(ite != personal.end()){
+               return ite->value;
+            }else{
+               return "";
+            }
+         }
+
+      private:
+		 /*For accounts to store their personal specific key-value data.
+		 key needs to be string and follow rules: only contain a-z,0-5,not longer than 12.
+		 for the key shorter than 12,will add 0 at higher bits.
+		 by doing this we can use key as uint64_t,to save space and easy use.
+		 usage: ex. dapp owner can call sethomepage to set its homepage,guiding users to their dapp*/
+		 struct [[eosio::table]] personal{
+			uint64_t key;
+			std::string readablekey;
+			std::string value;
+			EOSLIB_SERIALIZE(personal,(key)(readablekey)(value))
+				
+			uint64_t primary_key()const { return key; }
+		 };
+		 typedef eosio::multi_index< "personaldata"_n, personal > personal_table;
+   };
+
+} /// namespace eosio

--- a/personal.bos/src/personal.bos.cpp
+++ b/personal.bos/src/personal.bos.cpp
@@ -1,0 +1,38 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
+
+#include <personal.bos/personal.bos.hpp>
+
+namespace eosio {
+
+void personal_contract::sethomepage( name account, std::string url){
+   eosio_assert( url.size() <= 256, "url is too long");
+   eosio_assert( url.find("http") == 0, "illegal url");
+   setpersonal( account, "homepage", url);
+}
+
+void personal_contract::setpersonal(name account,std::string key,std::string value){
+   require_auth( account );
+   eosio_assert( key.size() <= 12 , "key should be less than 12" );
+   //not support too long value, for safety.
+   eosio_assert( value.size() <= 1024 , "value should be less than 1024" );
+   name key_name{ std::string_view(key) };
+   personal_table personal( _self , account.value );
+   auto ite = personal.find( key_name.value );
+   if( ite != personal.end() ){
+	  personal.modify( ite, account , [&](auto& data){
+		 data.value = value;
+	  });
+   }else{
+	  personal.emplace( account , [&](auto& data){
+		 data.key = key_name.value;
+		 data.readablekey = key;
+		 data.value = value;
+	  });
+   }
+}
+} 
+
+EOSIO_DISPATCH( eosio::personal_contract, (sethomepage)(setpersonal) )

--- a/tests/contracts.hpp.in
+++ b/tests/contracts.hpp.in
@@ -19,6 +19,9 @@ struct contracts {
    static std::vector<uint8_t> bios_wasm() { return read_wasm("${CMAKE_BINARY_DIR}/../eosio.bios/eosio.bios.wasm"); }
    static std::string          bios_wast() { return read_wast("${CMAKE_BINARY_DIR}/../eosio.bios/eosio.bios.wast"); }
    static std::vector<char>    bios_abi() { return read_abi("${CMAKE_BINARY_DIR}/../eosio.bios/eosio.bios.abi"); }
+   static std::vector<uint8_t> personal_wasm() { return read_wasm("${CMAKE_BINARY_DIR}/../personal.bos/personal.bos.wasm"); }
+   static std::string          personal_wast() { return read_wast("${CMAKE_BINARY_DIR}/../personal.bos/personal.bos.wast"); }
+   static std::vector<char>    personal_abi() { return read_abi("${CMAKE_BINARY_DIR}/../personal.bos/personal.bos.abi"); }
 
    struct util {
       static std::vector<uint8_t> test_api_wasm() { return read_wasm("${CMAKE_SOURCE_DIR}/test_contracts/test_api.wasm"); }

--- a/tests/personal.bos_tests.cpp
+++ b/tests/personal.bos_tests.cpp
@@ -1,0 +1,139 @@
+#include <boost/test/unit_test.hpp>
+#include <eosio/testing/tester.hpp>
+#include <eosio/chain/abi_serializer.hpp>
+#include "eosio.system_tester.hpp"
+
+#include "Runtime/Runtime.h"
+
+#include <fc/variant_object.hpp>
+
+using namespace eosio::testing;
+using namespace eosio;
+using namespace eosio::chain;
+using namespace eosio::testing;
+using namespace fc;
+using namespace std;
+
+using mvo = fc::mutable_variant_object;
+
+class personal_bos_tester : public tester {
+public:
+
+   personal_bos_tester() {
+      produce_blocks( 2 );
+
+      create_accounts( { N(alice), N(bob), N(eosio.token),N(personal.bos) } );
+      produce_blocks( 2 );
+
+      set_code( N(personal.bos), contracts::personal_wasm() );
+      set_abi( N(personal.bos), contracts::personal_abi().data() );
+
+      produce_blocks();
+
+      const auto& accnt = control->db().get<account_object,by_name>( N(personal.bos) );
+      abi_def abi;
+      BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
+      abi_ser.set_abi(abi, abi_serializer_max_time);
+   }
+
+   action_result push_action( const account_name& signer, const action_name &name, const variant_object &data ) {
+      string action_type_name = abi_ser.get_action_type(name);
+
+      action act;
+      act.account = N(personal.bos);
+      act.name    = name;
+      act.data    = abi_ser.variant_to_binary( action_type_name, data,abi_serializer_max_time );
+
+      return base_tester::push_action( std::move(act), uint64_t(signer));
+   }
+
+   fc::variant get_personal( const name act,const string key ) {
+      name key_name{key};
+      vector<char> data = get_row_by_account( N(personal.bos), act, N(personaldata), key_name.value );
+      return abi_ser.binary_to_variant( "personal", data, abi_serializer_max_time );
+   }
+
+   abi_serializer abi_ser;
+};
+
+BOOST_AUTO_TEST_SUITE(personal_bos_tests)
+
+BOOST_FIXTURE_TEST_CASE( set_personal_and_homepage, personal_bos_tester ) try {
+   //only owner can call setpersonal
+   BOOST_REQUIRE_EQUAL(error("missing authority of alice"),
+                        push_action( N(bob), N(setpersonal), mvo()
+                                          ("account", "alice")
+                                          ("key", "favorfood")
+                                          ("value", "pizza"))
+   );
+
+   //key length check
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("key should be less than 12"),
+                        push_action( N(alice), N(setpersonal), mvo()
+                                          ("account", "alice")
+                                          ("key", "tooooooooooolongkey")
+                                          ("value", "somevalue"))
+   );
+
+   //value length check
+   string* long_value=new string(1025,'a');
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("value should be less than 1024"),
+                        push_action( N(alice), N(setpersonal), mvo()
+                                          ("account", "alice")
+                                          ("key", "somekey")
+                                          ("value",*long_value))
+   );
+
+   //setpersonal should success,and check result
+   BOOST_REQUIRE_EQUAL(success(),
+                        push_action( N(alice), N(setpersonal), mvo()
+                                          ("account", "alice")
+                                          ("key", "favorfood")
+                                          ("value","pizza")
+                        )
+   );
+   auto data=get_personal(N(alice),"favorfood");
+   BOOST_REQUIRE_EQUAL(0,data["readablekey"].as_string().find("favorfood"));
+   BOOST_REQUIRE_EQUAL(0,data["value"].as_string().find("pizza"));
+
+   //setpersonal to other value check
+   BOOST_REQUIRE_EQUAL(success(),
+                        push_action( N(alice), N(setpersonal), mvo()
+                                          ("account", "alice")
+                                          ("key", "favorfood")
+                                          ("value","noodles")
+                        )
+   );
+   data=get_personal(N(alice),"favorfood");
+   BOOST_REQUIRE_EQUAL(0,data["readablekey"].as_string().find("favorfood"));
+   BOOST_REQUIRE_EQUAL(0,data["value"].as_string().find("noodles"));
+
+   //sethomepage check
+   //long url check
+   string *long_url=new string(257,'a');
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("url is too long"),
+                        push_action( N(alice), N(sethomepage), mvo()
+                                      ("account", "alice")
+                                      ("url",*long_url))
+   );
+
+   //url prefix check
+   string url="abcdefg";
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("illegal url"),
+                        push_action( N(alice), N(sethomepage), mvo()
+                                          ("account", "alice")
+                                          ("url",url))
+   );
+
+   //sethomepage should success,and check result
+   BOOST_REQUIRE_EQUAL(success(),
+                       push_action( N(alice), N(sethomepage), mvo()
+                                          ("account", "alice")
+                                          ("url","http://somepage.com")
+                       )
+   );
+   data=get_personal(N(alice),"homepage");
+   BOOST_REQUIRE_EQUAL(0,data["value"].as_string().find("http://somepage.com"));
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
add new contract: personal.bos, which has actions:

1.setpersonal
2.sethomepage
this contract has a table "personaldata" ,which's a key-value map to store customized public info for accounts. it has 3 columns:
   key: the primary uint64_t key, which's compressed from "readablekey"
   readablekey: user input "key",should be shorter than 12, will use it to generate "key"
   value: the value, should be less than 1024.
setpersonal:user can call to set the key-value they wish,and read it via get table.
sethomepage:the same with setpersonal, just the key is fixed to "homepage", by supplying homepage, dapp can easily guide user to their homepage.
            with commits on "boscore/bos",user can also use "cleos set personal ..." and "cleos get account ..." to set personaldata and read homepage.
also add an inline interface "getpersonal" in personal.bos.hpp for easily accessing this multi-index for contracts.

Deployment:
when deploying,you need to create account "personal.bos" and set this contract to it to let it working.

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
add new contract: personal.bos
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
this "personal.bos" contract has 2 actions, 1 inline interface. has 1 multi-index: personaldata.
actions:
    setpersonal
    sethomepage
inline interface:
    getpersonal" in personal.bos.hpp 
multi-index:
    code:"personal.bos", scope: account name, table name: "personaldata".
  it's a key-value map to store customized public info for accounts. it has 3 columns:
     key: the primary uint64_t key, which's compressed from "readablekey"
     readablekey: user input "key",should be shorter than 12, will use it to generate "key"
     value: the value, should be less than 1024.
     user can call "setpersonal" to set the key-value they wish,and read it via get table.
"sethomepage" is the same with "setpersonal", just the key is fixed to "homepage", by supplying homepage, dapp can easily guide user to their homepage.
    with commits on "boscore/bos",user can also use "cleos set personal ..." and "cleos get account ..." to set personaldata and read homepage.
    inline interface "getpersonal" in personal.bos.hpp is for easily accessing this multi-index for contracts.

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->
need to create account "personal.bos" and call "set contract" to set this contract to it.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
abi change:
added "personal.bos" contract, which has 2 actions:
1. setpersonal
2. sethomepage
and 1 multi-index: "personaldata".

in personal.bos.hpp, it has a inline interface: "get_personal", with it other contracts can easily access "personaldata".

## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
