### PR TITLE
3s LIB v3.0.0 version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,9 @@ cmake_minimum_required(VERSION 3.5)
 
 project(eosio_contracts)
 
-set(VERSION_MAJOR 2)
+set(VERSION_MAJOR 3)
 set(VERSION_MINOR 0)
-set(VERSION_PATCH 3)
+set(VERSION_PATCH 0)
 #set(VERSION_SUFFIX rc3)
 
 if (VERSION_SUFFIX)
@@ -20,8 +20,8 @@ find_package(eosio.cdt)
 
 message(STATUS "Building eosio.contracts v${VERSION_FULL}")
 
-set(EOSIO_CDT_VERSION_MIN "2.0")
-set(EOSIO_CDT_VERSION_SOFT_MAX "2.0")
+set(EOSIO_CDT_VERSION_MIN "3.0")
+set(EOSIO_CDT_VERSION_SOFT_MAX "3.0")
 #set(EOSIO_CDT_VERSION_HARD_MAX "")
 
 ### Check the version of eosio.cdt

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # bos.contracts
 
 
-## BOSCore Version : v2.0.3
+## BOSCore Version : v3.0.0
 ### EOSIO Contracts Version: v1.6.0
 
 The design of the EOSIO blockchain calls for a number of smart contracts that are run at a privileged permission level in order to support functions such as block producer registration and voting, token staking for CPU and network bandwidth, RAM purchasing, multi-sig, etc.  These smart contracts are referred to as the system, token, msig and wrap (formerly known as sudo) contracts.
@@ -17,8 +17,8 @@ The following unprivileged contract(s) are also part of the system.
 
 Dependencies:
 
-* [bos v2.0.x](https://github.com/boscore/bos/releases/tag/v2.0.3)
-* [bos.cdt v2.0.x](https://github.com/boscore/bos.cdt/releases/tag/v2.0.2)
+* [bos v3.0.x](https://github.com/boscore/bos/releases)
+* [bos.cdt v3.0.x](https://github.com/boscore/bos.cdt/releases)
 
 The ibc contracts had moved to a independent repository [ibc_contracts](https://github.com/boscore/ibc_contracts).
 

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -131,6 +131,15 @@ namespace eosiosystem {
       EOSLIB_SERIALIZE( eosio_global_state3, (last_vpay_state_update)(total_vpay_share_change_rate) )
    };
 
+   struct [[eosio::table("upgrade"), eosio::contract("eosio.system")]] upgrade_state  {
+//      std::string  active_proposal = "none";
+      uint32_t     target_block_num;
+//      uint16_t     status;
+
+      EOSLIB_SERIALIZE( upgrade_state, (target_block_num) )
+   };
+
+
    struct [[eosio::table, eosio::contract("eosio.system")]] producer_info {
       name                  owner;
       double                total_votes = 0;
@@ -223,6 +232,9 @@ namespace eosiosystem {
    typedef eosio::singleton< "global3"_n, eosio_global_state3 > global_state3_singleton;
    typedef eosio::singleton< "guaranminres"_n, eosio_guaranteed_min_res > guaranteed_min_res_singleton;      // *bos*
 
+   typedef eosio::singleton< "upgrade"_n, upgrade_state > upgrade_singleton;
+
+   //   static constexpr uint32_t     max_inflation_rate = 5;  // 5% annual inflation
    static constexpr uint32_t     seconds_per_day = 24 * 3600;
 
    struct [[eosio::table,eosio::contract("eosio.system")]] rex_pool {
@@ -329,6 +341,8 @@ namespace eosiosystem {
          rex_fund_table          _rexfunds;
          rex_balance_table       _rexbalance;
          rex_order_table         _rexorders;
+         upgrade_singleton       _upgrade;
+         upgrade_state           _ustate;
 
       public:
          static constexpr eosio::name active_permission{"active"_n};
@@ -605,6 +619,15 @@ namespace eosiosystem {
 
          [[eosio::action]]
          void bidrefund( name bidder, name newname );
+
+         struct upgrade_proposal {
+//             std::string      proposal_name;
+             uint32_t    target_block_num;
+         };
+
+         //functions defined in upgrade.cpp
+         [[eosio::action]]
+         void setupgrade( const upgrade_proposal& up);
 
          using init_action = eosio::action_wrapper<"init"_n, &system_contract::init>;
          using setacctram_action = eosio::action_wrapper<"setacctram"_n, &system_contract::setacctram>;

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -8,6 +8,7 @@
 #include "exchange_state.cpp"
 #include <map>
 #include "rex.cpp"
+#include "upgrade.cpp"
 
 namespace eosiosystem {
 
@@ -24,12 +25,15 @@ namespace eosiosystem {
     _rexpool(_self, _self.value),
     _rexfunds(_self, _self.value),
     _rexbalance(_self, _self.value),
-    _rexorders(_self, _self.value)
+    _rexorders(_self, _self.value),
+    _upgrade(_self, _self.value)
    {
       //print( "construct system\n" );
       _gstate  = _global.exists() ? _global.get() : get_default_parameters();
       _gstate2 = _global2.exists() ? _global2.get() : eosio_global_state2{};
       _gstate3 = _global3.exists() ? _global3.get() : eosio_global_state3{};
+
+      _ustate = _upgrade.exists() ? _upgrade.get() : upgrade_state{};
    }
 
    eosio_global_state system_contract::get_default_parameters() {
@@ -62,6 +66,8 @@ namespace eosiosystem {
       _global.set( _gstate, _self );
       _global2.set( _gstate2, _self );
       _global3.set( _gstate3, _self );
+
+      _upgrade.set( _ustate, _self );
    }
 
    void system_contract::setram( uint64_t max_ram_size ) {
@@ -572,4 +578,6 @@ EOSIO_DISPATCH( eosiosystem::system_contract,
      (regproducer)(unregprod)(voteproducer)(regproxy)
      // producer_pay.cpp
      (onblock)(claimrewards)
+     //upgrade.cpp
+     (setupgrade)
 )

--- a/contracts/eosio.system/src/upgrade.cpp
+++ b/contracts/eosio.system/src/upgrade.cpp
@@ -1,0 +1,16 @@
+#include <eosio.system/eosio.system.hpp>
+
+namespace eosiosystem {
+
+    void system_contract::setupgrade( const upgrade_proposal& up) {
+        require_auth( _self );
+
+        auto params = eosio::upgrade_parameters{};
+        params.target_block_num = up.target_block_num;
+        (eosio::upgrade_parameters&)(_ustate) = params;
+        set_upgrade_parameters( params );
+
+//        _ustate.active_proposal = up.proposal_name;
+        _ustate.target_block_num = up.target_block_num;
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required( VERSION 3.5 )
 
 
-set(EOSIO_VERSION_MIN "2.0")
-set(EOSIO_VERSION_SOFT_MAX "2.0")
+set(EOSIO_VERSION_MIN "3.0")
+set(EOSIO_VERSION_SOFT_MAX "3.0")
 
 #set(EOSIO_VERSION_HARD_MAX "")
 


### PR DESCRIPTION
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
* upgraded version of system contract used for dpos-pbft (bos)
* decouple setupgrade arg and wast interface param
* comment unnecessary attributes.
* add built system contracts
* add unittest in build script.

## API Changes
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->

set target upgrade block hight example:
```
cleos push action eosio eosio setupgrade '{"up":{"target_block_num":1000}}' -p eosio
```