### PR TITLE
update eosio.msig contract.

### DIFF
--- a/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
+++ b/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
@@ -23,6 +23,16 @@ namespace eosio {
          void exec( name proposer, name proposal_name, name executer );
          [[eosio::action]]
          void invalidate( name account );
+         [[eosio::action]]
+         void oppose( name proposer, name proposal_name, permission_level level,
+                       const eosio::binary_extension<eosio::checksum256>& proposal_hash );
+         [[eosio::action]]
+         void unoppose( name proposer, name proposal_name, permission_level level );
+		 [[eosio::action]]
+         void abstain( name proposer, name proposal_name, permission_level level,
+                       const eosio::binary_extension<eosio::checksum256>& proposal_hash );
+         [[eosio::action]]
+         void unabstain( name proposer, name proposal_name, permission_level level );
 
          using propose_action = eosio::action_wrapper<"propose"_n, &multisig::propose>;
          using approve_action = eosio::action_wrapper<"approve"_n, &multisig::approve>;
@@ -66,6 +76,17 @@ namespace eosio {
             uint64_t primary_key()const { return proposal_name.value; }
          };
          typedef eosio::multi_index< "approvals2"_n, approvals_info > approvals;
+
+         //one can only approval, or oppose, or abstain.
+         //if he/she wants to change opinion of oppose, needs to unoppose first.
+         //oppose/abstain won't be counted in when trying exec. only approvals are counted.
+         struct [[eosio::table]] opposes_info {
+             name             proposal_name;
+             std::vector<permission_level> opposed_approvals;
+             std::vector<permission_level> abstained_approvals;
+             uint64_t primary_key() const { return proposal_name.value; }
+         };
+         typedef eosio::multi_index< "opposes"_n, opposes_info > opposes;
 
          struct [[eosio::table]] invalidation {
             name         account;


### PR DESCRIPTION
add new actions:
   oppose    //oppose to current proposal
   unoppose  //undo previous oppose
   abstain   //abstain to current proposal
   unabstain //undo previous abstain
you could only approve or oppose or abstain at a time.
ex. if you approved to a proposal,now you wish to oppose it, you need to unapprove first, then you can oppose.
oppose and abstain only show attitude, won't affect exec/cancel/invalidate.
if you get enough approvals in an proposal, you can exec it, it will ignore the oppose/abstain when doing exec.

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
update eosio.msig contract.

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
add new actions:
   oppose    //oppose to current proposal
   unoppose  //undo previous oppose
   abstain   //abstain to current proposal
   unabstain //undo previous abstain
you could only approve or oppose or abstain at a time.
ex. if you approved to a proposal,now you wish to oppose it, you need to unapprove first, then you can oppose.
oppose and abstain only show attitude, won't affect exec/cancel/invalidate.
if you get enough approvals in an proposal, you can exec it, it will ignore the oppose/abstain when doing exec.

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->
need to redeploy eosio.msig contract.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
add new actions:
   oppose    //oppose to current proposal
   unoppose  //undo previous oppose
   abstain   //abstain to current proposal
   unabstain //undo previous abstain
add new multi-index:
   name: opposes
   struct: {
      name proposal_name;      //primary key
      vector<permission_level> opposed_approvals;
      vector<permission_level> abstained_approvals;
   }

      

## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
